### PR TITLE
Allow multiple attributes in CLI flag via comma-separated list

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -5,6 +5,7 @@ package aws
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/aws/aws-sdk-go-v2/service/acm"

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v0.22.0
 	github.com/fatih/color v1.9.0
 	github.com/gobwas/glob v0.2.3
+	github.com/gruntwork-io/terratest v0.23.0
 	github.com/jckuester/terradozer v0.0.0-20200523195146-e66de6fa55f3
 	github.com/onsi/gomega v1.9.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbMjkk=
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -127,6 +128,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -177,6 +179,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/gruntwork-io/gruntwork-cli v0.5.1/go.mod h1:IBX21bESC1/LGoV7jhXKUnTQTZgQ6dYRsoj/VqxUSZQ=
+github.com/gruntwork-io/terratest v0.23.0 h1:JmGeqO0r5zRLAV55T67NEmPZArz9lN3RKd0moAKhIT4=
 github.com/gruntwork-io/terratest v0.23.0/go.mod h1:+fVff0FQYuRzCF3LKpKF9ac+4w384LDcwLZt7O/KmEE=
 github.com/hashicorp/aws-sdk-go-base v0.4.0/go.mod h1:eRhlz3c4nhqxFZJAahJEFL7gh6Jyj5rQmQc7F9eHFyQ=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
@@ -365,6 +368,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6DI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
+github.com/pquerna/otp v1.2.0 h1:/A3+Jn+cagqayeR3iHs/L62m5ue7710D35zl1zJ1kok=
 github.com/pquerna/otp v1.2.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/internal/attributes_flag.go
+++ b/internal/attributes_flag.go
@@ -1,0 +1,27 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Attributes []string
+
+func (attrs *Attributes) String() string {
+	return fmt.Sprint(*attrs)
+}
+
+// Set is the method to set the flag value, part of the flag.Value interface.
+// Set's argument is a string to be parsed to set the flag.
+// It's a comma-separated list, so we split it.
+func (attrs *Attributes) Set(attributes string) error {
+	if len(*attrs) > 0 {
+		return fmt.Errorf("attributes flag already set")
+	}
+
+	for _, attr := range strings.Split(attributes, ",") {
+		*attrs = append(*attrs, attr)
+	}
+
+	return nil
+}

--- a/resource/utils.go
+++ b/resource/utils.go
@@ -106,18 +106,24 @@ func GetStates(resources []aws.Resource, provider *provider.TerraformProvider) [
 	return resources
 }
 
-func HasAttribute(attrName, terraformType string, provider *provider.TerraformProvider) (bool, error) {
+// HasAttributes returns only the attributes that the given Terraform resource type supports out of a given
+// list of attributes.
+func HasAttributes(attributes []string, terraformType string, provider *provider.TerraformProvider) (map[string]bool, error) {
 	schema, err := provider.GetSchemaForResource(terraformType)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	_, ok := schema.Block.Attributes[attrName]
-	if ok {
-		return true, nil
+	result := map[string]bool{}
+
+	for _, attr := range attributes {
+		_, ok := schema.Block.Attributes[attr]
+		if ok {
+			result[attr] = true
+		}
 	}
 
-	return false, nil
+	return result, nil
 }
 
 // GetAttribute returns any Terraform attribute of a resource by name.

--- a/test/acc_test.go
+++ b/test/acc_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/onsi/gomega/gexec"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +17,65 @@ import (
 const (
 	packagePath = "github.com/jckuester/awsls"
 )
+
+func TestAcc_Attributes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping acceptance test.")
+	}
+
+	env := InitEnv(t)
+
+	terraformDir := "./test-fixtures/aws-vpc"
+
+	terraformOptions := GetTerraformOptions(terraformDir, env)
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	actualVpcID := terraform.Output(t, terraformOptions, "vpc_id")
+	AssertVpcExists(t, actualVpcID, env)
+
+	tests := []struct {
+		name         string
+		attributes   []string
+		expectedLogs []string
+	}{
+		{
+			name:       "single attributes",
+			attributes: []string{"-attributes", "tags", "aws_vpc"},
+			expectedLogs: []string{
+				"REGION      CREATED   TAGS",
+				"us-west-2   N/A       bar=baz,foo=bar",
+			},
+		},
+		{
+			name:       "multiple attributes",
+			attributes: []string{"-attributes", "tags,cidr_block", "aws_vpc"},
+			expectedLogs: []string{
+				"REGION      CREATED   TAGS              CIDR_BLOCK",
+				"us-west-2   N/A       bar=baz,foo=bar   10.0.0.0/16",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			logBuffer, err := runBinary(t, tc.attributes...)
+			require.NoError(t, err)
+
+			AssertVpcExists(t, actualVpcID, env)
+
+			actualLogs := logBuffer.String()
+
+			for _, expectedLogEntry := range tc.expectedLogs {
+				assert.Contains(t, actualLogs, expectedLogEntry)
+			}
+
+			fmt.Println(actualLogs)
+		})
+	}
+}
 
 func TestAcc_NonExistingResourceType(t *testing.T) {
 	if testing.Short() {
@@ -26,7 +87,7 @@ func TestAcc_NonExistingResourceType(t *testing.T) {
 
 	actualLogs := logBuffer.String()
 
-	assert.Contains(t, actualLogs, "Error: not a valid Terraform AWS resource type: aws_foo")
+	assert.Contains(t, actualLogs, "Error: no resource type found: aws_foo")
 
 	fmt.Println(actualLogs)
 }
@@ -36,12 +97,32 @@ func TestAcc_UnsupportedResourceType(t *testing.T) {
 		t.Skip("Skipping acceptance test.")
 	}
 
-	logBuffer, err := runBinary(t, "aws_opsworks_mysql_layer")
+	logBuffer, err := runBinary(t, "-debug", "aws_opsworks_mysql_layer")
 	require.Error(t, err)
 
 	actualLogs := logBuffer.String()
 
-	assert.Contains(t, actualLogs, "Error: resource type is not (yet) supported: aws_opsworks_mysql_layer")
+	assert.Contains(t, actualLogs, "resource type not (yet) supported: aws_opsworks_mysql_layer")
+	assert.Contains(t, actualLogs, "Error: no resource type found: aws_opsworks_mysql_layer")
+
+	fmt.Println(actualLogs)
+}
+
+func TestAcc_Version(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping acceptance test.")
+	}
+
+	logBuffer, err := runBinary(t, "-version")
+	require.NoError(t, err)
+
+	actualLogs := logBuffer.String()
+
+	assert.Contains(t, actualLogs, fmt.Sprintf(`
+version: dev
+commit: ?
+built at: ?
+using: %s`, runtime.Version()))
 
 	fmt.Println(actualLogs)
 }

--- a/test/helper.go
+++ b/test/helper.go
@@ -1,0 +1,77 @@
+// Package test contains acceptance tests.
+package test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+const testTfStateBucket = "awsls-testacc-tfstate-492043"
+
+// EnvVars contains environment variables for that must be set for tests.
+type EnvVars struct {
+	AWSRegion  string
+	AWSProfile string
+}
+
+// InitEnv sets environment variables for acceptance tests.
+func InitEnv(t *testing.T) EnvVars {
+	t.Helper()
+
+	profile := os.Getenv("AWS_PROFILE")
+	if profile == "" {
+		t.Fatal("env variable AWS_PROFILE needs to be set for tests")
+	}
+
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		t.Fatal("env variable AWS_DEFAULT_REGION needs to be set for tests")
+	}
+
+	return EnvVars{
+		AWSProfile: profile,
+		AWSRegion:  region,
+	}
+}
+
+func GetTerraformOptions(terraformDir string, env EnvVars, optionalVars ...map[string]interface{}) *terraform.Options {
+	name := "awsls-testacc-" + strings.ToLower(random.UniqueId())
+
+	vars := map[string]interface{}{
+		"region":  env.AWSRegion,
+		"profile": env.AWSProfile,
+		"name":    name,
+	}
+
+	if len(optionalVars) > 0 {
+		for k, v := range optionalVars[0] {
+			vars[k] = v
+		}
+	}
+
+	return &terraform.Options{
+		TerraformDir: terraformDir,
+		NoColor:      true,
+		Vars:         vars,
+		// BackendConfig defines where to store the Terraform state files of tests
+		BackendConfig: map[string]interface{}{
+			"bucket":  testTfStateBucket,
+			"key":     fmt.Sprintf("%s.tfstate", name),
+			"region":  env.AWSRegion,
+			"profile": env.AWSProfile,
+			"encrypt": true,
+		},
+	}
+}
+
+func AssertVpcExists(t *testing.T, actualVpcID string, env EnvVars) {
+	_, err := aws.GetVpcByIdE(t, actualVpcID, env.AWSRegion)
+	assert.NoError(t, err, "resource has been unexpectedly deleted")
+}

--- a/test/test-fixtures/aws-vpc/main.tf
+++ b/test/test-fixtures/aws-vpc/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  version = "~> 2.0"
+
+  profile = var.profile
+  region  = var.region
+}
+
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "s3" {
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    foo = "bar"
+    bar = "baz"
+  }
+}

--- a/test/test-fixtures/aws-vpc/outputs.tf
+++ b/test/test-fixtures/aws-vpc/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc_id" {
+  value = aws_vpc.test.id
+}

--- a/test/test-fixtures/aws-vpc/variables.tf
+++ b/test/test-fixtures/aws-vpc/variables.tf
@@ -1,0 +1,11 @@
+variable "profile" {
+  description = "The named profile for the AWS account that will be deployed to"
+}
+
+variable "region" {
+  description = "The AWS region to deploy to"
+}
+
+variable "name" {
+  description = "The name of test"
+}


### PR DESCRIPTION
Instead of a single attribute, showing multiple ones
is supported now.