### PR TITLE
Fix: Retry on throttling exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,3 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-deploy:
-  - provider: script
-    skip_cleanup: true
-    script: curl -sL https://git.io/goreleaser | bash
-    on:
-      tags: true
-notifications:
-  email: false

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ To see options available run `awsls --help`.
 It's recommended to install a specific version of awsls available on the
 [releases page](https://github.com/jckuester/awsls/releases).
 
-Here is the recommended way to install awsls v0.1.1:
+Here is the recommended way to install awsls v0.1.2:
 
 ```bash
 # install it into ./bin/
-curl -sSfL https://raw.githubusercontent.com/jckuester/awsls/master/install.sh | sh -s v0.1.1
+curl -sSfL https://raw.githubusercontent.com/jckuester/awsls/master/install.sh | sh -s v0.1.2
 ```
 
 ## Supported resources

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/gobwas/glob v0.2.3
 	github.com/gruntwork-io/terratest v0.23.0
-	github.com/jckuester/terradozer v0.1.0
+	github.com/jckuester/terradozer v0.1.2
 	github.com/onsi/gomega v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,16 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jckuester/terradozer v0.1.0 h1:dsZHaY1vH0XNDDIAensa4IkoL7+WKUqDpEu7xl5hg/E=
 github.com/jckuester/terradozer v0.1.0/go.mod h1:ZHLoxb3vdsXGCmxeUb7vPy/T6yPzecD0rn1NWdH9aww=
+github.com/jckuester/terradozer v0.1.2-0.20200623114140-02c9e39dc96c h1:hu4Z34Yi103XfbHOrHZFq3sxLEZb5TJxpGIpNUtWk+0=
+github.com/jckuester/terradozer v0.1.2-0.20200623114140-02c9e39dc96c/go.mod h1:ZHLoxb3vdsXGCmxeUb7vPy/T6yPzecD0rn1NWdH9aww=
+github.com/jckuester/terradozer v0.1.2-0.20200624204437-291967afd87f h1:7Y5vjl5vd70CqCLqLEqAAJl3mawaEPYMxs6KUyi3x/Q=
+github.com/jckuester/terradozer v0.1.2-0.20200624204437-291967afd87f/go.mod h1:ZHLoxb3vdsXGCmxeUb7vPy/T6yPzecD0rn1NWdH9aww=
+github.com/jckuester/terradozer v0.1.2-0.20200624204932-33dfddac419e h1:L/E/6IEnRIT0vLlSY9b+YjLXlfpWzd3OxzAkSNO+6WM=
+github.com/jckuester/terradozer v0.1.2-0.20200624204932-33dfddac419e/go.mod h1:ZHLoxb3vdsXGCmxeUb7vPy/T6yPzecD0rn1NWdH9aww=
+github.com/jckuester/terradozer v0.1.2-0.20200624205446-4b3da038bf68 h1:vedpby/TmBtPYckKogpNgUGDgOwnXUM5x0U+4BZkStk=
+github.com/jckuester/terradozer v0.1.2-0.20200624205446-4b3da038bf68/go.mod h1:ZHLoxb3vdsXGCmxeUb7vPy/T6yPzecD0rn1NWdH9aww=
+github.com/jckuester/terradozer v0.1.2 h1:E4oN3pk9aVTJgzmVySMiMr/dEwd6s6LqNTTDpaRh/mc=
+github.com/jckuester/terradozer v0.1.2/go.mod h1:ZHLoxb3vdsXGCmxeUb7vPy/T6yPzecD0rn1NWdH9aww=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
Fixes https://github.com/jckuester/awsls/issues/4

See also where the real fix happens https://github.com/jckuester/terradozer/pull/11

Throttling exception appears when updating the resource state in parallel via the Terraform AWS Provider. The AWS SDK does already retry on throttling and the provider uses a max retry count of 25, but this doesn't seem to be sufficient.