### PR TITLE
Goreleaser brew support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GO_RELEASER }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 bin/
 coverage.txt
 awsls
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,13 @@ builds:
     - freebsd
     env:
       - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
     ldflags: -s -w -X github.com/jckuester/awsls/internal.version={{.Version}} -X github.com/jckuester/awsls/internal.commit={{.ShortCommit}} -X github.com/jckuester/awsls/internal.date={{.Date}}
 
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ archives:
 
 brews:
 - tap:
-    owner: jckuester
+    owner: rothgar
     name: homebrew-tap
   homepage: "https://github.com/jckuester/awsls"
   description: "A list command for AWS resources"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ archives:
 
 brews:
 - tap:
-    owner: rothgar
+    owner: jckuester
     name: homebrew-tap
   homepage: "https://github.com/jckuester/awsls"
   description: "A list command for AWS resources"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,3 +13,21 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+
+brews:
+- github:
+    owner: rothgar
+    name: homebrew-tap
+  homepage: "https://github.com/jckuester/awsls"
+  description: "A list command for AWS resources"
+  folder: Formula
+
+checksum:
+  name_template: 'checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ archives:
         format: zip
 
 brews:
-- github:
+- tap:
     owner: rothgar
     name: homebrew-tap
   homepage: "https://github.com/jckuester/awsls"


### PR DESCRIPTION
Here's a base template for homebrew support.

You can install it from my tap via `brew install rothgar/tap/awsls` I changed the owner back to you for this PR.

To make a release
- export GITHUB_TOKEN with repo write access
- run `goreleaser release --rm-dist`

I couldn't find where you're creating the existing changelogs. I added it in the template but we can remove it if you want to stick with your current method. I also added checksums.txt to be added to the releases. You can see how it looks for the release here https://github.com/rothgar/awsls/releases/tag/v1.16.0

We can also add Linux arm support if you'd like. Once macOS arm support lands in go we should be able to update goreleaser and add support there too.

Fixes #23 