### PR TITLE
Update goreleaser-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: 1.16.x
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist --timeout 60m


### PR DESCRIPTION
I believe this includes a newer version of the homebrew formula which fixes #45

via https://github.com/goreleaser/goreleaser/pull/2591